### PR TITLE
feat: Support multiple reports in the same pipeline

### DIFF
--- a/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
+++ b/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
@@ -66,8 +66,7 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
 
     public render(): JSX.Element {
 
-        console.trace("We're rendering!");
-        console.trace("Current state is: " + this.state);
+        console.trace("Current rendering state is {0}", this.state);
         if (this.state.reports?.length 
             && this.state.selectedIndex != null
             &&  this.state.reports.length  >= this.state.selectedIndex ) {

--- a/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
+++ b/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
@@ -12,7 +12,7 @@ import { BuildReference, Attachment } from "azure-devops-extension-api/Build/Bui
 
 export interface IBuildResultTabData {
     reports: IReport[] | null;
-    selectdReportText: string | null
+    selectedIndex: number | null;
     loadSuccess: boolean;
 }
 
@@ -30,7 +30,7 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
         this.state = {
             reports: null,
             loadSuccess: false,
-            selectdReportText: null
+            selectedIndex : null
         };
     }
 
@@ -40,10 +40,14 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
         var items = [];
         for (let i = 0; i < this.state.reports.length; i++) {
             const element = this.state.reports[i];
-            items.push(<li onClick={() => {
+            let className = '';
+            if (this.state.selectedIndex == i) {
+                className = 'active';
+            }
+            items.push(<li className={className} onClick={() => {
                 this.setState(
                     {
-                        selectdReportText: element.reportText
+                        selectedIndex: i
                     }
                 );
             }}>{element.name}</li>) ;
@@ -61,10 +65,13 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
    }
 
     public render(): JSX.Element {
-        if (this.state.reports?.length &&this.state.selectdReportText ) {
+
+        if (this.state.reports?.length 
+            && this.state.selectedIndex != null
+            &&  this.state.reports.length  >= this.state.selectedIndex ) {
 
             const _reportList = this.renderReportList();
-            let augmentedReportText = this.augmentReportTextWithIframeResizerContent(this.state.selectdReportText);
+            let augmentedReportText = this.augmentReportTextWithIframeResizerContent(this.state.reports[this.state.selectedIndex].reportText as string);
             return (
                 <>
                     {_reportList}
@@ -73,7 +80,7 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
                         id="html-report-frame"
                         checkOrigin={false}
                         frameBorder="0"
-                        style={{ width: '1px', minWidth: '100%'}}
+                        style={{ width: '1px', minWidth: '100%', minHeight: '90vh'}}
                         scrolling={true}
                         marginHeight={0}
                         marginWidth={0}

--- a/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
+++ b/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
@@ -66,6 +66,8 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
 
     public render(): JSX.Element {
 
+        console.trace("We're rendering!");
+        console.trace("Current state is: " + this.state);
         if (this.state.reports?.length 
             && this.state.selectedIndex != null
             &&  this.state.reports.length  >= this.state.selectedIndex ) {

--- a/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
+++ b/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
@@ -163,7 +163,7 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
                 }
             }
             this.setState({
-                reports: _reports.filter(_item => _item.reportText != '').map((_item) => { 
+                reports: _reports.filter(_item => _item.reportText != null).map((_item) => { 
                     return {reportText : _item.reportText, name: _item.name};
                 }),
                 loadSuccess: true
@@ -175,7 +175,7 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
         }
     }
 
-    private async getAttachmentFromMetadataUrl(attachmentMetadata: Attachment, buildClient: BuildRestClient, project: IProjectInfo, build: BuildReference): Promise<string> {
+    private async getAttachmentFromMetadataUrl(attachmentMetadata: Attachment, buildClient: BuildRestClient, project: IProjectInfo, build: BuildReference): Promise<string | null> {
         console.trace("Attachment {0} contains file url {1}", attachmentMetadata.name, attachmentMetadata._links.self.href);
 
         const reportUrl: string = attachmentMetadata._links.self.href;
@@ -186,12 +186,11 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
             console.trace("Attachment timelineId {0} and recordId {1} found", timelineId, recordId);
             const attachment = await buildClient.getAttachment(project.id, build.id, timelineId, recordId, this.reportType, attachmentMetadata.name);
             const attachmentText = new TextDecoder('utf-8').decode(new Uint8Array(attachment));
-            // Now we set component state with attachmentText
             return attachmentText;
         }
         else {
             console.error("Attachment timelineId or recordId not found..");
-            return '';
+            return null;
         }
     }
 

--- a/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
+++ b/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
@@ -12,7 +12,7 @@ import { BuildReference, Attachment } from "azure-devops-extension-api/Build/Bui
 
 export interface IBuildResultTabData {
     reports: IReport[] | null;
-    selectedIndex: number | null;
+    selectedIndex: number;
     loadSuccess: boolean;
 }
 
@@ -30,7 +30,7 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
         this.state = {
             reports: null,
             loadSuccess: false,
-            selectedIndex : null
+            selectedIndex : 1
         };
     }
 

--- a/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
+++ b/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
@@ -30,7 +30,7 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
         this.state = {
             reports: null,
             loadSuccess: false,
-            selectedIndex : 1
+            selectedIndex : 0
         };
     }
 
@@ -67,9 +67,7 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
     public render(): JSX.Element {
 
         console.trace("Current rendering state is {0}", this.state);
-        if (this.state.reports?.length 
-            && this.state.selectedIndex != null
-            &&  this.state.reports.length  >= this.state.selectedIndex ) {
+        if (this.state.reports?.length) {
 
             const _reportList = this.renderReportList();
             let augmentedReportText = this.augmentReportTextWithIframeResizerContent(this.state.reports[this.state.selectedIndex].reportText as string);

--- a/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
+++ b/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
@@ -11,8 +11,14 @@ import { BuildRestClient } from "azure-devops-extension-api/Build/BuildClient"
 import { BuildReference, Attachment } from "azure-devops-extension-api/Build/Build";
 
 export interface IBuildResultTabData {
-    reportText: string | null;
+    reports: IReport[] | null;
+    selectdReportText: string | null
     loadSuccess: boolean;
+}
+
+export interface IReport {
+    reportText: string | null,
+    name: string
 }
 
 export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
@@ -22,16 +28,46 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
     constructor(props: {}) {
         super(props);
         this.state = {
-            reportText: null,
-            loadSuccess: false
+            reports: null,
+            loadSuccess: false,
+            selectdReportText: null
         };
     }
 
+   public renderReportList(): JSX.Element{
+
+    if(this.state.reports?.length){
+        var items = [];
+        for (let i = 0; i < this.state.reports.length; i++) {
+            const element = this.state.reports[i];
+            items.push(<li onClick={() => {
+                this.setState(
+                    {
+                        selectdReportText: element.reportText
+                    }
+                );
+            }}>{element.name}</li>) ;
+        }
+        return(
+            <ul>
+            {items}
+            </ul>
+        );
+    }
+   
+    return(
+        <div></div>
+      );
+   }
+
     public render(): JSX.Element {
-        if (this.state.reportText?.length) {
-            let augmentedReportText = this.augmentReportTextWithIframeResizerContent(this.state.reportText);
+        if (this.state.reports?.length &&this.state.selectdReportText ) {
+
+            const _reportList = this.renderReportList();
+            let augmentedReportText = this.augmentReportTextWithIframeResizerContent(this.state.selectdReportText);
             return (
                 <>
+                    {_reportList}
                     <IframeResizer
                         src={this.getGeneratedPageURL(augmentedReportText)}
                         id="html-report-frame"
@@ -52,7 +88,7 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
     public async componentDidMount() {
         SDK.init({ loaded: false });
 
-        if(!this.state.reportText) {
+        if(!this.state.reports) {
             await this.initializeState();
         }
 
@@ -103,21 +139,36 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
         const reportAttachments = await buildClient.getAttachments(project.id, build.id, this.reportType);
 
         if (reportAttachments.some(e => e)) {
-            const attachmentMetadata = this.getAttachmentMetadata(reportAttachments);
 
-            if (attachmentMetadata._links?.self?.href) {
-                await this.getAttachmentFromMetadataUrl(attachmentMetadata, buildClient, project, build);
+            const _reports = [];
+
+            for (let i = 0; i < reportAttachments.length; i++) {
+                const attachmentMetadata = reportAttachments[i];
+
+                if (attachmentMetadata._links?.self?.href) {
+                    _reports.push({
+                        reportText: await this.getAttachmentFromMetadataUrl(attachmentMetadata, buildClient, project, build),
+                        name: attachmentMetadata.name
+                    });
+                }
+                else {
+                    console.error("Attachment file url not found..");
+                }
             }
-            else {
-                console.error("Attachment file url not found..");
-            }
+            this.setState({
+                reports: _reports.filter(_item => _item.reportText != '').map((_item) => { 
+                    return {reportText : _item.reportText, name: _item.name};
+                }),
+                loadSuccess: true
+            });
+            SDK.notifyLoadSucceeded();
         }
         else {
             console.error("No Attachments found..");
         }
     }
 
-    private async getAttachmentFromMetadataUrl(attachmentMetadata: Attachment, buildClient: BuildRestClient, project: IProjectInfo, build: BuildReference): Promise<void> {
+    private async getAttachmentFromMetadataUrl(attachmentMetadata: Attachment, buildClient: BuildRestClient, project: IProjectInfo, build: BuildReference): Promise<string> {
         console.trace("Attachment {0} contains file url {1}", attachmentMetadata.name, attachmentMetadata._links.self.href);
 
         const reportUrl: string = attachmentMetadata._links.self.href;
@@ -129,22 +180,12 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
             const attachment = await buildClient.getAttachment(project.id, build.id, timelineId, recordId, this.reportType, attachmentMetadata.name);
             const attachmentText = new TextDecoder('utf-8').decode(new Uint8Array(attachment));
             // Now we set component state with attachmentText
-            this.setState({
-                reportText: attachmentText,
-                loadSuccess: true
-            });
-            SDK.notifyLoadSucceeded();
+            return attachmentText;
         }
         else {
             console.error("Attachment timelineId or recordId not found..");
+            return '';
         }
-    }
-
-    private getAttachmentMetadata(reportAttachments : Attachment[]) {
-        console.trace("Found {0} attachments for {1}", reportAttachments.length, this.reportType);
-        const attachmentMetadata = reportAttachments[0];
-
-        return attachmentMetadata;
     }
 
     private async getProject(): Promise<IProjectInfo> {

--- a/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
+++ b/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
@@ -159,7 +159,7 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
                     });
                 }
                 else {
-                    console.error("Attachment file url not found..");
+                    console.error(`Attachment ${attachmentMetadata.name} file url not found..`);
                 }
             }
             this.setState({

--- a/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
+++ b/extension/DisplayBuildResultReport/src/DisplayBuildResultTab.tsx
@@ -36,7 +36,7 @@ export class BuildResultTab extends React.Component<{}, IBuildResultTabData>
 
    public renderReportList(): JSX.Element{
 
-    if(this.state.reports?.length){
+    if(this.state.reports?.length && this.state.reports.length > 1){
         var items = [];
         for (let i = 0; i < this.state.reports.length; i++) {
             const element = this.state.reports[i];

--- a/extension/DisplayBuildResultReport/static/build-results-report-tab.html
+++ b/extension/DisplayBuildResultReport/static/build-results-report-tab.html
@@ -12,12 +12,20 @@
     li {
       float: left;
       display: block;
-      color: black;
+      color: #606770;
       text-align: center;
-      padding: 16px;
+      padding: 10px;
       text-decoration: none;
       cursor: pointer;
+      font-weight: 500;
+      font-size: 18px;
+      font-family: system-ui,-apple-system, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif
     }
+
+    li.active{
+      color: #e84b39;
+    }
+
     </style>
   <body>
     <div id="mutation-report-frame"></div>

--- a/extension/DisplayBuildResultReport/static/build-results-report-tab.html
+++ b/extension/DisplayBuildResultReport/static/build-results-report-tab.html
@@ -1,5 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
+  <style>
+    ul {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+      background-color: transparent;
+    }
+    
+    li {
+      float: left;
+      display: block;
+      color: black;
+      text-align: center;
+      padding: 16px;
+      text-decoration: none;
+      cursor: pointer;
+    }
+    </style>
   <body>
     <div id="mutation-report-frame"></div>
     <script type="text/javascript" src="main.js" charset="utf-8"></script>

--- a/extension/PublishMutationReport/src/publish.ts
+++ b/extension/PublishMutationReport/src/publish.ts
@@ -2,20 +2,25 @@ import * as tl from 'azure-pipelines-task-lib';
 
 function publish() {
     try {
-        var reportPath = findReport();
-        for (let i = 0; i < reportPath.length; i++) {
-            const element = reportPath[i];
+        var reportPaths = findReports();
+        for (let i = 0; i < reportPaths.length; i++) {
+            const element = reportPaths[i];
 
-            tl.addAttachment("stryker-mutator.mutation-report", "mutation-report-"+ (i+1)+".html", element);
+            let currentReport = i+1;
+            let progress = currentReport / reportPaths.length * 100
+            tl.setProgress(progress, "Uploading reports");
+            console.info("Uploading report " + currentReport + " of " + reportPaths.length);
+            tl.addAttachment("stryker-mutator.mutation-report", "mutation-report-"+currentReport+".html", element);
         }
-        tl.setResult(tl.TaskResult.Succeeded, "Mutation report uploaded: " + reportPath);
+        
+        tl.setResult(tl.TaskResult.Succeeded, "");
     }
     catch (err) {
         tl.setResult(tl.TaskResult.Failed, err.message);
     }
 }
 
-function findReport(): string[] {
+function findReports(): string[] {
     
     const reportPattern: string = tl.getInput('reportPattern', true) as string;
 
@@ -26,9 +31,10 @@ function findReport(): string[] {
     var reportPaths = tl.findMatch(tl.getVariable("System.DefaultWorkingDirectory") || process.cwd(), reportPattern);
 
     if (!reportPaths || !reportPaths.length) {
-        tl.setResult(tl.TaskResult.Failed, "No report found with filepath pattern " + reportPattern, true);
+        tl.setResult(tl.TaskResult.Failed, "No reports found with filepath pattern " + reportPattern, true);
     }
 
+    console.info("Found " + reportPaths.length + " reports.")
     return reportPaths;
 }
 

--- a/extension/PublishMutationReport/src/publish.ts
+++ b/extension/PublishMutationReport/src/publish.ts
@@ -7,7 +7,7 @@ function publish() {
             const element = reportPaths[i];
 
             let currentReport = i+1;
-            let progress = currentReport / reportPaths.length * 100
+            let progress = currentReport / reportPaths.length * 100;
             tl.setProgress(progress, "Uploading reports");
             console.info("Uploading report " + currentReport + " of " + reportPaths.length);
             tl.addAttachment("stryker-mutator.mutation-report", "mutation-report-"+currentReport+".html", element);

--- a/extension/PublishMutationReport/src/publish.ts
+++ b/extension/PublishMutationReport/src/publish.ts
@@ -3,7 +3,11 @@ import * as tl from 'azure-pipelines-task-lib';
 function publish() {
     try {
         var reportPath = findReport();
-        tl.addAttachment("stryker-mutator.mutation-report", "mutation-report-"+ tl.getVariable("Build.BuildId")+".html", reportPath);
+        for (let i = 0; i < reportPath.length; i++) {
+            const element = reportPath[i];
+
+            tl.addAttachment("stryker-mutator.mutation-report", "mutation-report-"+ i +".html", element);
+        }
         tl.setResult(tl.TaskResult.Succeeded, "Mutation report uploaded: " + reportPath);
     }
     catch (err) {
@@ -11,9 +15,9 @@ function publish() {
     }
 }
 
-function findReport(): string {
+function findReport(): string[] {
     
-    const reportPattern: string = tl.getInput('reportPattern', true);
+    const reportPattern: string = tl.getInput('reportPattern', true) as string;
 
     if(reportPattern.length == 0) {
         tl.setResult(tl.TaskResult.Failed, "Report filepath cannot be empty. Please provide a path to the report.", true);
@@ -25,11 +29,7 @@ function findReport(): string {
         tl.setResult(tl.TaskResult.Failed, "No report found with filepath pattern " + reportPattern, true);
     }
 
-    if(reportPaths.length > 1) {
-        tl.setResult(tl.TaskResult.SucceededWithIssues, "Multiple reports were found using pattern " + reportPattern + ". Using report " + reportPaths[0])
-    }
-
-    return reportPaths[0];
+    return reportPaths;
 }
 
 publish();

--- a/extension/PublishMutationReport/src/publish.ts
+++ b/extension/PublishMutationReport/src/publish.ts
@@ -6,7 +6,7 @@ function publish() {
         for (let i = 0; i < reportPath.length; i++) {
             const element = reportPath[i];
 
-            tl.addAttachment("stryker-mutator.mutation-report", "mutation-report-"+ i +".html", element);
+            tl.addAttachment("stryker-mutator.mutation-report", "mutation-report-"+ (i+1)+".html", element);
         }
         tl.setResult(tl.TaskResult.Succeeded, "Mutation report uploaded: " + reportPath);
     }

--- a/extension/PublishMutationReport/task.json
+++ b/extension/PublishMutationReport/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 14
+    "Patch": 15
   },
   "instanceNameFormat": "Publish Mutation Test Report",
   "inputs": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -5867,9 +5867,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "minimist-options": {
@@ -6089,20 +6089,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "mkdirp-infer-owner": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "With this extension you add the mutation report to your build summary so you can view the mutation test result on azure devops.",
   "author": "Rouke Broersma",
   "scripts": {
-    "bootstrap": "lerna bootstrap",
+    "bootstrap": "npm install && lerna bootstrap",
     "compile": "lerna run compile",
     "bump:task": "lerna run bump:task",
     "bump:task:minor": "lerna run bump:task:minor",


### PR DESCRIPTION
This is a very fast and simple solution to enable multiple reports

i dont know how to test it in a real pipeline on Azure Dev Ops, soo a made some mocks for see the changes ...

The results will be something like this
![image](https://user-images.githubusercontent.com/20740973/118364478-ecdf0180-b56e-11eb-9bd8-8071a04ee761.png)

I named the reports like mutation-report-1,mutation-report-2, etc

If there is a suggestion or anything to improve, please let me know.