### PR TITLE
Add report tab display name

### DIFF
--- a/docs/extension-description.md
+++ b/docs/extension-description.md
@@ -17,6 +17,7 @@ In YAML pipelines add the following after the test step:
   displayName: 'Publish Mutation Test Report'
   inputs:
     reportPattern: '**/mutation-report.html'
+    reportDisplayName: 'My_Report'
 ```
 
 ### Classic pipelines

--- a/extension/PublishMutationReport/src/publish.ts
+++ b/extension/PublishMutationReport/src/publish.ts
@@ -3,9 +3,9 @@ import * as tl from 'azure-pipelines-task-lib';
 function publish() {
     try {
         var reportPaths = findReports();
-        let reportName: string = tl.getInput('reportDisplayName', true) as string;
+        let reportName: string = tl.getInput('reportDisplayName', false) as string;
 
-        if (reportName.length == 0) {
+        if (!reportName?.trim()) {
           reportName = 'mutation-report';
         }
 

--- a/extension/PublishMutationReport/src/publish.ts
+++ b/extension/PublishMutationReport/src/publish.ts
@@ -3,6 +3,12 @@ import * as tl from 'azure-pipelines-task-lib';
 function publish() {
     try {
         var reportPaths = findReports();
+        let reportName: string = tl.getInput('reportDisplayName', true) as string;
+
+        if (reportName.length == 0) {
+          reportName = 'mutation-report';
+        }
+
         for (let i = 0; i < reportPaths.length; i++) {
             const element = reportPaths[i];
 
@@ -10,7 +16,7 @@ function publish() {
             let progress = currentReport / reportPaths.length * 100;
             tl.setProgress(progress, "Uploading reports");
             console.info("Uploading report " + currentReport + " of " + reportPaths.length);
-            tl.addAttachment("stryker-mutator.mutation-report", "mutation-report-"+currentReport+".html", element);
+            tl.addAttachment("stryker-mutator.mutation-report", reportName+"-"+currentReport+".html", element);
         }
         
         tl.setResult(tl.TaskResult.Succeeded, "");

--- a/extension/PublishMutationReport/task.json
+++ b/extension/PublishMutationReport/task.json
@@ -8,8 +8,8 @@
   "author": "Rouke Broersma",
   "version": {
     "Major": 0,
-    "Minor": 0,
-    "Patch": 15
+    "Minor": 1,
+    "Patch": 0
   },
   "instanceNameFormat": "Publish Mutation Test Report",
   "inputs": [

--- a/extension/PublishMutationReport/task.json
+++ b/extension/PublishMutationReport/task.json
@@ -20,6 +20,13 @@
       "defaultValue": "**/mutation-report.html",
       "required": true,
       "helpMarkDown": "For help configuring your mutation test tool to output a html report see the tool's website. For [stryker see](https://stryker-mutator.io/)"
+    },
+    {
+      "name": "reportDisplayName",
+      "type": "string",
+      "label": "Display name for the report tab. If you use multiple reports in a pipeline you can differentiate between them by setting the name.",
+      "defaultValue": "mutation-report",
+      "required": false
     }
   ],
   "execution": {


### PR DESCRIPTION
Adding a report tab display name allows users to specify a name for each
report created in a matrix pipeline. This allows the user to identify
each report at a glance without opening each tab.