### PR TITLE
Update ReplaceTokens task to v5 to fix node version error in build. Minor spelling/typo fix.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ stages:
     - script: echo "##vso[build.updatebuildnumber]$(packageVersionDev)"
       displayName: 'Set build number'
 
-    - task: replacetokens@3
+    - task: replacetokens@5
       inputs:
         targetFiles: '**/azure-devops-extension*.json'
 

--- a/docs/extension-description.md
+++ b/docs/extension-description.md
@@ -1,6 +1,6 @@
 # Mutation Report Publisher
 
-Have you been using [Stryker](https://stryker-mutator.io) or any other mutation testing framework? With this extionsion it is easier than ever to see the results directly in your build result tab.
+Have you been using [Stryker](https://stryker-mutator.io) or any other mutation testing framework? With this extension it is easier than ever to see the results directly in your build result tab.
 
 ## Configuration
 

--- a/pipeline-templates/deployment-stage.yml
+++ b/pipeline-templates/deployment-stage.yml
@@ -30,7 +30,7 @@ stages:
               vsixFile: $(Pipeline.Workspace)/${{ parameters.vsixFilePattern }}
               updateTasksId: ${{ parameters.isTestPackage }}
               updateTasksVersion: false
-          - task: IsAzureDevOpsExtensionValid@3
+          - task: IsAzureDevOpsExtensionValid@4
             inputs:
               connectTo: 'VsTeam'
               connectedServiceName: 'visual studio marketplace stryker-mutator'

--- a/pipeline-templates/deployment-stage.yml
+++ b/pipeline-templates/deployment-stage.yml
@@ -30,7 +30,7 @@ stages:
               vsixFile: $(Pipeline.Workspace)/${{ parameters.vsixFilePattern }}
               updateTasksId: ${{ parameters.isTestPackage }}
               updateTasksVersion: false
-          - task: IsAzureDevOpsExtensionValid@2
+          - task: IsAzureDevOpsExtensionValid@3
             inputs:
               connectTo: 'VsTeam'
               connectedServiceName: 'visual studio marketplace stryker-mutator'

--- a/pipeline-templates/deployment-stage.yml
+++ b/pipeline-templates/deployment-stage.yml
@@ -22,7 +22,7 @@ stages:
           - task: TfxInstaller@4
             inputs:
               checkLatest: true
-          - task: PublishAzureDevOpsExtension@2
+          - task: PublishAzureDevOpsExtension@4
             inputs:
               connectTo: 'VsTeam'
               connectedServiceName: 'visual studio marketplace stryker-mutator'

--- a/pipeline-templates/deployment-stage.yml
+++ b/pipeline-templates/deployment-stage.yml
@@ -19,7 +19,7 @@ stages:
       runOnce:
         deploy:
           steps:
-          - task: TfxInstaller@2
+          - task: TfxInstaller@4
             inputs:
               checkLatest: true
           - task: PublishAzureDevOpsExtension@2


### PR DESCRIPTION
To fix the build error currently happening on the ADO pipeline.

Using this:
https://github.com/qetza/vsts-replacetokens-task/blob/master/tasks/ReplaceTokensV5/task.json

Also fixes a minor typo on the .md displayed on the VS Extensions Gallery.